### PR TITLE
 productsテーブルとcategorysテーブルの関係を多対多から１対多へ変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 |buyer_id|references|index: true, foreign_key: true|
 |name|text|null: false|
 |description|text|null: false|
-|category_id|references|index: true, foreign_key: true|
+|category_id|references|null: false, index: true, foreign_key: true|
 |brand_id|references|index: true, foreign_key: true|
 |state_id|references|null: false, foreign_key: true|
 |size_id|references|foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ add_index :products, [:name, :description]
 ## user_addressesテーブル
 
 |user_id|references|null: false, index: true, foreign_key: true|
-|postcode|string||
+|postcode|string|
 |prefecture_id|references|foreign_key: true|
 |city|string||
 |block|string||

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 |buyer_id|references|index: true, foreign_key: true|
 |name|text|null: false|
 |description|text|null: false|
+|category_id|references|index: true, foreign_key: true|
 |brand_id|references|index: true, foreign_key: true|
 |state_id|references|null: false, foreign_key: true|
 |size_id|references|foreign_key: true|
@@ -93,14 +94,13 @@ add_index :products, [:name, :description]
 - belongs_to :seller, class_name: 'User'
 - belongs_to :buyer, class_name: 'User'
 - belongs_to_active_hash :prefecture
+- belongs_to :category
 - belongs_to :brand
 - belongs_to_active_hash :size
 - belongs_to_active_hash :state
 - belongs_to_active_hash :paying_side
 - belongs_to_active_hash :delivery_day
 - has_many :images, dependent: :destroy
-- has_many :products_categorys
-- has_many :categorys, through products_categorys
 
 
 ## imagesテーブル
@@ -124,27 +124,16 @@ add_index :products, [:name, :description]
 - has_many :products
 
 
-## products_categorysテーブル
-
-|Column|Type|Options|
-|------|----|-------|
-|product_id|references|null: false, index: true, foreign_key: true|
-|category_id|references|null: false, index: true, foreign_key: true|
-
-### Association
-- belongs_to :product
-- belongs_to :category
-
-
 ## categorysテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string||
+|name|string|null: false|
+|ancestry|string||
 
 ### Association
-- has_many :products_categorys
-- has_many :products, through products_categorys
+- has_many :products
+- has_ancestry
 
 
 ## sns_credentialsテーブル

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ add_index :products, [:name, :description]
 
 ## user_addressesテーブル
 
+|Column|Type|Options|
+|------|----|-------|
 |user_id|references|null: false, index: true, foreign_key: true|
 |postcode|string|
 |prefecture_id|references|foreign_key: true|


### PR DESCRIPTION
# WHAT
gem ancestryを使用した構成に修正

# WHY
カテゴリーデータの呼び出しを容易にする為

<img width="1004" alt="スクリーンショット 2019-08-25 10 40 23" src="https://user-images.githubusercontent.com/51224937/63644492-2e89a200-c725-11e9-9291-e4874ff13bde.png">
