### PR TITLE
発送元・お届け先住所変更（マイページ）

### DIFF
--- a/app/assets/stylesheets/mypage/payment.scss
+++ b/app/assets/stylesheets/mypage/payment.scss
@@ -1,16 +1,3 @@
-.mypage {
-  width: 700px;
-  &__title {
-    height: 50px;
-    padding: 8px 24px;
-    background-color: $white;
-    font-size: 24px;
-    font-weight: bold;
-    text-align: center;
-    line-height: 34px;
-    border-bottom: 2px solid $bg-gray;
-  }
-}
 .payment {
   position: relative;
   padding: 64px;

--- a/app/assets/stylesheets/mypage/personal-info.scss
+++ b/app/assets/stylesheets/mypage/personal-info.scss
@@ -1,7 +1,6 @@
 .personal-info {
   padding: 64px;
   background-color: $white;
-  border-top: 1px solid $bg-gray;
   font-size: 14px;
   &__form {
     &__description {

--- a/app/assets/stylesheets/mypage/shared.scss
+++ b/app/assets/stylesheets/mypage/shared.scss
@@ -15,5 +15,6 @@
     font-weight: bold;
     text-align: center;
     line-height: 34px;
+    border-bottom: 1px solid $bg-gray;
   }
 }

--- a/app/controllers/delivery_addresses_controller.rb
+++ b/app/controllers/delivery_addresses_controller.rb
@@ -5,11 +5,10 @@ class DeliveryAddressesController < ApplicationController
   end
 
   def create
-    @delivery_address = DeliveryAddress.new(delivery_address_params)
-    @delivery_address.user = current_user
+    delivery_address = DeliveryAddress.new(delivery_address_params)
     # マイページで登録した場合はマイページへリダイレクトさせる
     if Rails.application.routes.recognize_path(request.referer)[:controller] == "mypages"
-      if @delivery_address.save!
+      if delivery_address.save!
         flash[:success] = '登録しました。'
       else
         flash.now[:danger] = '登録できませんでした。'
@@ -17,7 +16,7 @@ class DeliveryAddressesController < ApplicationController
       redirect_to delivery_address_user_mypage_path(current_user)
     # 新規登録フォームで登録した場合はカード登録へリダイレクトさせる
     else
-      if @delivery_address.save!
+      if delivery_address.save!
         redirect_to new_card_path
       else
         render new_address_path
@@ -38,7 +37,6 @@ private
 
   def delivery_address_params
     params.require(:delivery_address).permit(
-      :user_id,
       :last_name,
       :first_name,
       :last_name_kana,
@@ -49,6 +47,6 @@ private
       :block,
       :building,
       :phone_number
-    )
+    ).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/delivery_addresses_controller.rb
+++ b/app/controllers/delivery_addresses_controller.rb
@@ -1,4 +1,4 @@
-class AddressesController < ApplicationController
+class DeliveryAddressesController < ApplicationController
   before_action :authenticate_user!
   def new
     @delivery_address = DeliveryAddress.new

--- a/app/controllers/delivery_addresses_controller.rb
+++ b/app/controllers/delivery_addresses_controller.rb
@@ -7,10 +7,21 @@ class DeliveryAddressesController < ApplicationController
   def create
     @delivery_address = DeliveryAddress.new(delivery_address_params)
     @delivery_address.user = current_user
-    if @delivery_address.save!
-      redirect_to new_card_path
+    # マイページで登録した場合はマイページへリダイレクトさせる
+    if Rails.application.routes.recognize_path(request.referer)[:controller] == "mypages"
+      if @delivery_address.save!
+        flash[:success] = '登録しました。'
+      else
+        flash.now[:danger] = '登録できませんでした。'
+      end
+      redirect_to delivery_address_user_mypage_path(current_user)
+    # 新規登録フォームで登録した場合はカード登録へリダイレクトさせる
     else
-      render new_address_path
+      if @delivery_address.save!
+        redirect_to new_card_path
+      else
+        render new_address_path
+      end
     end
   end
 

--- a/app/controllers/delivery_addresses_controller.rb
+++ b/app/controllers/delivery_addresses_controller.rb
@@ -14,21 +14,30 @@ class DeliveryAddressesController < ApplicationController
     end
   end
 
+  def update
+    if current_user.delivery_address.update(delivery_address_params)
+      flash[:success] = '変更しました。'
+    else
+      flash.now[:danger] = '変更できませんでした。'
+    end
+    redirect_to delivery_address_user_mypage_path(current_user)
+  end
+
 private
 
-def delivery_address_params
-  params.require(:delivery_address).permit(
-    :user_id,
-    :last_name,
-    :first_name,
-    :last_name_kana,
-    :first_name_kana,
-    :postcode,
-    :prefecture_id,
-    :city,
-    :block,
-    :building,
-    :phone_number
-  )
-end
+  def delivery_address_params
+    params.require(:delivery_address).permit(
+      :user_id,
+      :last_name,
+      :first_name,
+      :last_name_kana,
+      :first_name_kana,
+      :postcode,
+      :prefecture_id,
+      :city,
+      :block,
+      :building,
+      :phone_number
+    )
+  end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -74,6 +74,9 @@ class MypagesController < ApplicationController
     end
   end
 
+  def delivery_address
+  end
+
   private
   def user_address_params
     params.permit(:postcode, :prefecture_id, :city, :block, :building).merge(user_id: current_user.id)

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -75,6 +75,8 @@ class MypagesController < ApplicationController
   end
 
   def delivery_address
+    @delivery_address = current_user.delivery_address
+    @delivery_address = DeliveryAddress.new if @delivery_address.nil?
   end
 
   private

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -75,8 +75,7 @@ class MypagesController < ApplicationController
   end
 
   def delivery_address
-    @delivery_address = current_user.delivery_address
-    @delivery_address = DeliveryAddress.new if @delivery_address.nil?
+    @delivery_address = current_user.delivery_address.nil? ? DeliveryAddress.new : current_user.delivery_address
   end
 
   private

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -42,7 +42,7 @@ def create
   )
   if @user.save
     sign_in(@user)
-    redirect_to new_address_path
+    redirect_to new_delivery_address_path
   else
     render customer_info_signup_index_path
   end

--- a/app/views/delivery_addresses/new.html.haml
+++ b/app/views/delivery_addresses/new.html.haml
@@ -7,7 +7,7 @@
       発送元・お届け先住所入力
     .customer-entry__body
       .customer-entry__body__form
-        = form_with model:@delivery_address,local:true, url:addresses_path,class: 'customer-entry__body__form' do |f|
+        = form_with model:@delivery_address,local:true, class: 'customer-entry__body__form' do |f|
           .entry-content
             %label.entry-content__text お名前
             %span.entry-content__require 必須

--- a/app/views/mypages/delivery_address.html.haml
+++ b/app/views/mypages/delivery_address.html.haml
@@ -10,3 +10,50 @@
 
 .mypage-main
   = render 'shared/mypage-side-menu'
+
+  .mypage
+    %h2.mypage__head
+      発送元・お届け先住所変更
+
+    %section 
+      .customer-entry
+        .customer-entry__body
+          .customer-entry__body__form
+            = form_with model:@delivery_address,local:true, class: 'customer-entry__body__form' do |f|
+              .entry-content
+                %label.entry-content__text お名前
+                %span.entry-content__require 必須
+                = f.text_field :last_name, autocomplete: "last_name",placeholder:"例)山田",class:"entry-content__input-default",required:"",pattern:"[^\x20-\x7E]*"
+                = f.text_field :first_name, autocomplete: "first_name",placeholder:"例)彩",class:"entry-content__input-default",required:"",pattern:"[^\x20-\x7E]*"
+              .entry-content
+                %label.entry-content__text お名前カナ
+                %span.entry-content__require 必須
+                = f.text_field :last_name_kana, autocomplete: "last_name_kana",placeholder:"例)ヤマダ",class:"entry-content__input-default",required:"",pattern:"[\u30A1-\u30FF]*"
+                = f.text_field :first_name_kana, autocomplete: "first_name_kana",placeholder:"例)アヤ",class:"entry-content__input-default",required:"",pattern:"[\u30A1-\u30FF]*"
+              .entry-content
+                %label.entry-content__text 郵便番号
+                %span.entry-content__require 必須
+                = f.text_field :postcode, autocomplete: "mobile_number",placeholder:"例)123-4567",class:"entry-content__input-default",required:"",pattern:"[0-9]{3}-[0-9]{4}"
+              .entry-content
+                %label.entry-content__text 都道府県
+                %span.entry-content__require 必須
+                = fa_icon 'chevron-down'
+                = f.collection_select :prefecture_id, Prefecture.all, :id, :name,required:""
+              .entry-content
+                %label.entry-content__text 市区町村
+                %span.entry-content__require 必須
+                = f.text_field :city,autocomplete:"city",placeholder:"例)横浜市緑区",class:"entry-content__input-default",type:"text",required:"",pattern:"[^\x20-\x7E]*"
+              .entry-content
+                %label.entry-content__text 番地
+                %span.entry-content__require 必須
+                = f.text_field :block,autocomplete:"block",placeholder:"例)青山1-1-1",class:"entry-content__input-default",type:"text",required:""
+              .entry-content
+                %label.entry-content__text 建物名
+                %span.entry-content__any 任意
+                = f.text_field :building,autocomplete:"building",placeholder:"例)柳ビル103",class:"entry-content__input-default",type:"text"
+              .entry-content
+                %label.entry-content__text 電話番号
+                %span.entry-content__any 任意
+                = f.text_field :phone_number, autocomplete: "phone_number",placeholder:"例)09012345678",class:"entry-content__input-default",pattern:"0[0-9]{9,10}"
+              .entry-bottom__next
+                = f.submit "変更する", class: "entry-bottom__next__btn"

--- a/app/views/mypages/delivery_address.html.haml
+++ b/app/views/mypages/delivery_address.html.haml
@@ -1,0 +1,12 @@
+%header
+  = render 'shared/sub-header'
+
+%section
+  - breadcrumb :delivery_address
+  = render 'shared/breadcrumb'
+
+- flash.each do |message_type, message|
+  %div{class: "flash #{message_type}"}= message
+
+.mypage-main
+  = render 'shared/mypage-side-menu'

--- a/app/views/mypages/payment.html.haml
+++ b/app/views/mypages/payment.html.haml
@@ -12,7 +12,7 @@
   = render 'shared/mypage-side-menu'
 
   .mypage
-    %h2.mypage__title
+    %h2.mypage__head
       支払い方法
     %section.payment
       .payment__list

--- a/app/views/shared/_mypage-side-menu.html.haml
+++ b/app/views/shared/_mypage-side-menu.html.haml
@@ -76,7 +76,7 @@
       = fa_icon "angle-right", class: "mypage-side-menu__list__item__icon"
     %li.mypage-side-menu__list__item
       発送元・お届け先住所変更
-      = link_to '', "#", { class: "mypage-side-menu__list__item__btn" }
+      = link_to '', delivery_address_user_mypage_path, { class: "mypage-side-menu__list__item__btn" }
       = fa_icon "angle-right", class: "mypage-side-menu__list__item__icon"
     %li.mypage-side-menu__list__item
       支払い方法

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -30,3 +30,8 @@ crumb :listing_product do
   link "出品した商品 - 出品中", listing_product_user_mypage_path
   parent :mypage
 end
+
+crumb :delivery_address do
+  link "発送元・お届け先住所変更", delivery_address_user_mypage_path
+  parent :mypage
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   root 'tops#index'
   resources :tops, only: [:index]
 
-  resources :addresses, only: [:new,:create]
+  resources :delivery_addresses, only: [:new,:create,:update]
   resources :cards, only: [:new,:show,:create,:destroy]
   resources :signup, only: [:new,:index,:create] do
     collection do 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,14 +9,12 @@ Rails.application.routes.draw do
   root 'tops#index'
   resources :tops, only: [:index]
 
-  resources :delivery_addresses, only: [:new,:create,:update]
-  resources :cards, only: [:new,:show,:create,:destroy]
-  resources :signup, only: [:new,:index,:create] do
+  resources :delivery_addresses, only: [:new, :create, :update]
+  resources :cards, only: [:new, :show,:create, :destroy]
+  resources :signup, only: [:new, :create] do
     collection do 
       get 'customer_info'
       get 'sms_comfi'
-      get 'address'
-      get 'card'
       get 'complete'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
         post 'create_card'
         post 'personal_info' => 'mypages#create_user_address'
         get 'listing_product'
+        get 'delivery_address'
       end
     end
   end


### PR DESCRIPTION
# WHAT
マイページの発送元・お届け先住所変更ページで、住所を変更できる様にする

# WHY
ユーザーが一度登録した住所を変更できる様にする為